### PR TITLE
Fix wasm binary module file names

### DIFF
--- a/src/rollup-plugin-screeps.ts
+++ b/src/rollup-plugin-screeps.ts
@@ -130,7 +130,7 @@ export function getFileList(outputFile: string) {
     if (file.endsWith('.js')) {
         code[file.replace(/\.js$/i, '')] = fs.readFileSync(path.join(base, file), 'utf8');
     } else {
-        code[file] = {
+        code[file.replace(/\.wasm$/i, '')] = {
             binary: fs.readFileSync(path.join(base, file)).toString('base64')
         }
     }


### PR DESCRIPTION
re-do of https://github.com/Arcath/rollup-plugin-screeps/pull/23 against new screepers fork